### PR TITLE
Remove src from package.json ignored paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     ".npmignore",
     "Gruntfile.js",
     "package.json",
-    "src",
     "test"
   ],
   "devDependencies": {


### PR DESCRIPTION
I wanted to use the .scss files, but they're not shipped with the npm version.